### PR TITLE
fixed 2 placeholders

### DIFF
--- a/src/me/F64/papiexpansions/koth/ExpansionKoTH.java
+++ b/src/me/F64/papiexpansions/koth/ExpansionKoTH.java
@@ -45,8 +45,8 @@ public class ExpansionKoTH extends PlaceholderExpansion {
             if(identifier.equals("live_"+name+"_name")) return koth.getName();
             if(identifier.equals("live_"+name+"_loot")) return koth.getLoot();
             if(identifier.equals("live_"+name+"_x")) return ""+koth.getMiddle().getBlockX();
-            if(identifier.equals("live_"+name+"_y")) return ""+koth.getMiddle().getBlockX();
-            if(identifier.equals("live_"+name+"_z")) return ""+koth.getMiddle().getBlockX();
+            if(identifier.equals("live_"+name+"_y")) return ""+koth.getMiddle().getBlockY();
+            if(identifier.equals("live_"+name+"_z")) return ""+koth.getMiddle().getBlockZ();
             if(identifier.equals("live_"+name+"_world")) return ""+koth.getMiddle().getWorld().getName();
             
             if(identifier.equals("live_"+name+"_nextevent")) return TimeObject.getTimeTillNextEvent(koth);


### PR DESCRIPTION
```
        if(identifier.equals("next_x")) return ""+koth.getMiddle().getBlockX();
        if(identifier.equals("next_y")) return ""+koth.getMiddle().getBlockX();
        if(identifier.equals("next_z")) return ""+koth.getMiddle().getBlockX();
```

changed to 

```
        if(identifier.equals("next_x")) return ""+koth.getMiddle().getBlockX();
        if(identifier.equals("next_y")) return ""+koth.getMiddle().getBlockY();
        if(identifier.equals("next_z")) return ""+koth.getMiddle().getBlockZ();
```
